### PR TITLE
#3 Double html encoding in description and title

### DIFF
--- a/collective/ogtags/browser/viewlets.py
+++ b/collective/ogtags/browser/viewlets.py
@@ -1,11 +1,12 @@
-from zope.component import (ComponentLookupError, getMultiAdapter, getUtility,
-                            queryMultiAdapter)
-
 from Acquisition import aq_inner
 from collective.ogtags.browser.controlpanel import IOGTagsControlPanel
 from plone.app.layout.viewlets import ViewletBase
 from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.utils import safe_unicode
+from zope.component import ComponentLookupError
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
 
 
 class OGTagsViewlet(ViewletBase):

--- a/collective/ogtags/browser/viewlets.py
+++ b/collective/ogtags/browser/viewlets.py
@@ -1,20 +1,11 @@
+from zope.component import (ComponentLookupError, getMultiAdapter, getUtility,
+                            queryMultiAdapter)
+
 from Acquisition import aq_inner
 from collective.ogtags.browser.controlpanel import IOGTagsControlPanel
 from plone.app.layout.viewlets import ViewletBase
 from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.utils import safe_unicode
-from zope.component import ComponentLookupError
-from zope.component import getMultiAdapter
-from zope.component import getUtility
-from zope.component import queryMultiAdapter
-
-import cgi
-
-
-def escape(value):
-    """Extended escape, taken from quintagroup.seoptimizer."""
-    value = cgi.escape(value, True)
-    return value.replace("'", "&apos;")
 
 
 class OGTagsViewlet(ViewletBase):
@@ -48,13 +39,11 @@ class OGTagsViewlet(ViewletBase):
 
         # set title
         if title:
-            title = escape(title)
             tags['og:title'] = title
             tags['twitter:title'] = title
 
         # set description
         if description:
-            description = escape(description)
             tags['og:description'] = description
             tags['twitter:description'] = description
 


### PR DESCRIPTION
Tying to solve #3 

Looks like tal:attributes in viewlet template already escapes what's needed so the removed escape function causes the double escaping problem.
